### PR TITLE
Add multipart/form-data support for Ktor client and server

### DIFF
--- a/end2end-tests/ktor-client-jackson/build.gradle.kts
+++ b/end2end-tests/ktor-client-jackson/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
 
     // ktor test
     testImplementation("io.ktor:ktor-server-test-host:$ktorVersion")
+    testImplementation("io.ktor:ktor-server-content-negotiation:$ktorVersion")
     testImplementation("io.mockk:mockk:1.13.7")
 
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
@@ -49,17 +50,25 @@ tasks {
         "src/test/resources/examples/ktorClient/api.yaml"
     )
 
+    val generateMultipartCode = createGenerateCodeTask(
+        "generateMultipartCode",
+        "src/test/resources/examples/multipartFormData/api.yaml",
+        listOf("--base-package", "com.example.multipart")
+    )
+
     withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_17)
         }
         dependsOn(generateCode)
+        dependsOn(generateMultipartCode)
     }
 
     withType<Test> {
         useJUnitPlatform()
         jvmArgs = listOf("--add-opens=java.base/java.lang=ALL-UNNAMED", "--add-opens=java.base/java.util=ALL-UNNAMED")
         dependsOn(generateCode)
+        dependsOn(generateMultipartCode)
     }
 }
 
@@ -71,16 +80,22 @@ fun createGenerateCodeTask(name: String, apiFilePath: String, additionalArgs: Li
     outputs.cacheIf { true }
     classpath = rootProject.files("./build/libs/fabrikt-${rootProject.version}.jar")
     mainClass.set("com.cjbooms.fabrikt.cli.CodeGen")
+    val basePackage = if (additionalArgs.contains("--base-package")) {
+        additionalArgs[additionalArgs.indexOf("--base-package") + 1]
+    } else {
+        "com.example"
+    }
+    val filteredAdditionalArgs = additionalArgs.filterNot { it == "--base-package" || it == basePackage }
     args = listOf(
         "--output-directory", generationDir,
-        "--base-package", "com.example",
+        "--base-package", basePackage,
         "--api-file", apiFile,
         "--targets", "http_models",
         "--targets", "client",
         "--http-client-target", "ktor",
         "--serialization-library", "jackson",
         "--validation-library", "no_validation"
-    ).plus(additionalArgs)
+    ).plus(filteredAdditionalArgs)
     dependsOn(":jar")
     dependsOn(":shadowJar")
 }

--- a/end2end-tests/ktor-client-jackson/src/test/kotlin/com/cjbooms/fabrikt/clients/KtorClientMultipartTest.kt
+++ b/end2end-tests/ktor-client-jackson/src/test/kotlin/com/cjbooms/fabrikt/clients/KtorClientMultipartTest.kt
@@ -1,0 +1,231 @@
+package com.cjbooms.fabrikt.clients
+
+import com.example.multipart.client.FileUpload
+import com.example.multipart.client.FilesUploadClient
+import com.example.multipart.client.FilesUploadMultipleClient
+import com.example.multipart.client.NetworkResult
+import com.example.multipart.models.UploadResponse
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock.containing
+import com.github.tomakehurst.wiremock.client.WireMock.ok
+import com.github.tomakehurst.wiremock.client.WireMock.post
+import com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.serialization.jackson.jackson
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.assertInstanceOf
+import java.net.ServerSocket
+
+/**
+ * Tests for Ktor client multipart form-data uploads.
+ *
+ * Note: Ktor has a known bug where Content-Disposition parameters are sent unquoted
+ * (e.g., `name=file` instead of `name="file"`). This is tracked in:
+ * - https://github.com/ktorio/ktor/issues/1691
+ * - https://github.com/ktorio/ktor/issues/5157
+ *
+ * The assertions in these tests use `containing("name=file")` (unquoted) to match
+ * Ktor's actual behavior, even though the HTTP spec requires quoted values.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class KtorClientMultipartTest {
+    private val port: Int = ServerSocket(0).use { socket -> socket.localPort }
+    private val wiremock: WireMockServer = WireMockServer(options().port(port))
+    private val mapper = ObjectMapper().registerKotlinModule()
+
+    private fun createHttpClient() = HttpClient(CIO) {
+        install(ContentNegotiation) {
+            jackson()
+        }
+        defaultRequest {
+            url(wiremock.baseUrl())
+        }
+    }
+
+    @BeforeEach
+    fun setUp() {
+        wiremock.start()
+    }
+
+    @AfterEach
+    fun afterEach() {
+        wiremock.resetAll()
+        wiremock.stop()
+    }
+
+    @Test
+    fun `single file upload sends multipart request correctly`() = runBlocking {
+        val expectedResponse = UploadResponse(id = "file-123")
+
+        wiremock.stubFor(
+            post(urlEqualTo("/files/upload"))
+                .willReturn(
+                    ok()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(mapper.writeValueAsString(expectedResponse))
+                )
+        )
+
+        val client = FilesUploadClient(createHttpClient())
+        val fileContent = "Hello, World!".toByteArray()
+        val result = client.uploadFile(
+            file = FileUpload(fileContent)
+        )
+
+        assertInstanceOf<NetworkResult.Success<UploadResponse>>(result)
+
+        wiremock.verify(
+            postRequestedFor(urlEqualTo("/files/upload"))
+                .withHeader("Content-Type", containing("multipart/form-data"))
+                .withRequestBody(containing("name=file"))
+                .withRequestBody(containing("Hello, World!"))
+        )
+    }
+
+    @Test
+    fun `multiple files upload sends multipart request correctly`() = runBlocking {
+        val expectedResponse = UploadResponse(id = "file-multi")
+
+        wiremock.stubFor(
+            post(urlEqualTo("/files/upload-multiple"))
+                .willReturn(
+                    ok()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(mapper.writeValueAsString(expectedResponse))
+                )
+        )
+
+        val client = FilesUploadMultipleClient(createHttpClient())
+        val file1Content = "File 1 content".toByteArray()
+        val file2Content = "File 2 content".toByteArray()
+
+        val result = client.uploadMultipleFiles(
+            files = listOf(FileUpload(file1Content), FileUpload(file2Content))
+        )
+
+        assertInstanceOf<NetworkResult.Success<UploadResponse>>(result)
+
+        wiremock.verify(
+            postRequestedFor(urlEqualTo("/files/upload-multiple"))
+                .withHeader("Content-Type", containing("multipart/form-data"))
+                .withRequestBody(containing("name=files"))
+                .withRequestBody(containing("File 1 content"))
+                .withRequestBody(containing("File 2 content"))
+        )
+    }
+
+    @Test
+    fun `single file upload uses custom filename when provided`() = runBlocking {
+        val expectedResponse = UploadResponse(id = "file-custom")
+
+        wiremock.stubFor(
+            post(urlEqualTo("/files/upload"))
+                .willReturn(
+                    ok()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(mapper.writeValueAsString(expectedResponse))
+                )
+        )
+
+        val client = FilesUploadClient(createHttpClient())
+        val fileContent = "PNG image bytes".toByteArray()
+        val result = client.uploadFile(
+            file = FileUpload(fileContent, "my-image.png")
+        )
+
+        assertInstanceOf<NetworkResult.Success<UploadResponse>>(result)
+
+        wiremock.verify(
+            postRequestedFor(urlEqualTo("/files/upload"))
+                .withHeader("Content-Type", containing("multipart/form-data"))
+                .withRequestBody(containing("name=file"))
+                .withRequestBody(containing("""filename="my-image.png""""))
+                .withRequestBody(containing("PNG image bytes"))
+        )
+    }
+
+    @Test
+    fun `multiple files upload uses custom filenames when provided`() = runBlocking {
+        val expectedResponse = UploadResponse(id = "file-multi-custom")
+
+        wiremock.stubFor(
+            post(urlEqualTo("/files/upload-multiple"))
+                .willReturn(
+                    ok()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(mapper.writeValueAsString(expectedResponse))
+                )
+        )
+
+        val client = FilesUploadMultipleClient(createHttpClient())
+        val file1Content = "PDF content 1".toByteArray()
+        val file2Content = "PDF content 2".toByteArray()
+
+        val result = client.uploadMultipleFiles(
+            files = listOf(
+                FileUpload(file1Content, "doc1.pdf"),
+                FileUpload(file2Content, "doc2.pdf")
+            )
+        )
+
+        assertInstanceOf<NetworkResult.Success<UploadResponse>>(result)
+
+        wiremock.verify(
+            postRequestedFor(urlEqualTo("/files/upload-multiple"))
+                .withHeader("Content-Type", containing("multipart/form-data"))
+                .withRequestBody(containing("name=files"))
+                .withRequestBody(containing("""filename="doc1.pdf""""))
+                .withRequestBody(containing("PDF content 1"))
+                .withRequestBody(containing("""filename="doc2.pdf""""))
+                .withRequestBody(containing("PDF content 2"))
+        )
+    }
+
+    @Test
+    fun `multiple files upload allows partial filename specification`() = runBlocking {
+        val expectedResponse = UploadResponse(id = "file-partial")
+
+        wiremock.stubFor(
+            post(urlEqualTo("/files/upload-multiple"))
+                .willReturn(
+                    ok()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(mapper.writeValueAsString(expectedResponse))
+                )
+        )
+
+        val client = FilesUploadMultipleClient(createHttpClient())
+        val file1Content = "File 1".toByteArray()
+        val file2Content = "File 2".toByteArray()
+
+        // Only provide filename for first file, second uses default
+        val result = client.uploadMultipleFiles(
+            files = listOf(
+                FileUpload(file1Content, "custom.txt"),
+                FileUpload(file2Content)  // Uses default filename
+            )
+        )
+
+        assertInstanceOf<NetworkResult.Success<UploadResponse>>(result)
+
+        wiremock.verify(
+            postRequestedFor(urlEqualTo("/files/upload-multiple"))
+                .withHeader("Content-Type", containing("multipart/form-data"))
+                .withRequestBody(containing("name=files"))
+                .withRequestBody(containing("""filename="custom.txt""""))
+                .withRequestBody(containing("File 1"))
+                .withRequestBody(containing("File 2"))
+        )
+    }
+}

--- a/end2end-tests/ktor-client-kotlinx/src/test/kotlin/com/cjbooms/fabrikt/clients/KtorClientMultipartKotlinxTest.kt
+++ b/end2end-tests/ktor-client-kotlinx/src/test/kotlin/com/cjbooms/fabrikt/clients/KtorClientMultipartKotlinxTest.kt
@@ -1,0 +1,231 @@
+package com.cjbooms.fabrikt.clients
+
+import com.example.multipart.client.FileUpload
+import com.example.multipart.client.FilesUploadClient
+import com.example.multipart.client.FilesUploadMultipleClient
+import com.example.multipart.client.NetworkResult
+import com.example.multipart.models.UploadResponse
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock.containing
+import com.github.tomakehurst.wiremock.client.WireMock.ok
+import com.github.tomakehurst.wiremock.client.WireMock.post
+import com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.assertInstanceOf
+import java.net.ServerSocket
+
+/**
+ * Tests for Ktor client multipart form-data uploads with kotlinx.serialization.
+ *
+ * Note: Ktor has a known bug where Content-Disposition parameters are sent unquoted
+ * (e.g., `name=file` instead of `name="file"`). This is tracked in:
+ * - https://github.com/ktorio/ktor/issues/1691
+ * - https://github.com/ktorio/ktor/issues/5157
+ *
+ * The assertions in these tests use `containing("name=file")` (unquoted) to match
+ * Ktor's actual behavior, even though the HTTP spec requires quoted values.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class KtorClientMultipartKotlinxTest {
+    private val port: Int = ServerSocket(0).use { socket -> socket.localPort }
+    private val wiremock: WireMockServer = WireMockServer(options().port(port))
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private fun createHttpClient() = HttpClient(CIO) {
+        install(ContentNegotiation) {
+            json()
+        }
+        defaultRequest {
+            url(wiremock.baseUrl())
+        }
+    }
+
+    @BeforeEach
+    fun setUp() {
+        wiremock.start()
+    }
+
+    @AfterEach
+    fun afterEach() {
+        wiremock.resetAll()
+        wiremock.stop()
+    }
+
+    @Test
+    fun `single file upload sends multipart request correctly`() = runBlocking {
+        val expectedResponse = UploadResponse(id = "file-123")
+
+        wiremock.stubFor(
+            post(urlEqualTo("/files/upload"))
+                .willReturn(
+                    ok()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(json.encodeToString(expectedResponse))
+                )
+        )
+
+        val client = FilesUploadClient(createHttpClient())
+        val fileContent = "Hello, World!".toByteArray()
+        val result = client.uploadFile(
+            file = FileUpload(fileContent)
+        )
+
+        assertInstanceOf<NetworkResult.Success<UploadResponse>>(result)
+
+        wiremock.verify(
+            postRequestedFor(urlEqualTo("/files/upload"))
+                .withHeader("Content-Type", containing("multipart/form-data"))
+                .withRequestBody(containing("name=file"))
+                .withRequestBody(containing("Hello, World!"))
+        )
+    }
+
+    @Test
+    fun `multiple files upload sends multipart request correctly`() = runBlocking {
+        val expectedResponse = UploadResponse(id = "file-multi")
+
+        wiremock.stubFor(
+            post(urlEqualTo("/files/upload-multiple"))
+                .willReturn(
+                    ok()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(json.encodeToString(expectedResponse))
+                )
+        )
+
+        val client = FilesUploadMultipleClient(createHttpClient())
+        val file1Content = "File 1 content".toByteArray()
+        val file2Content = "File 2 content".toByteArray()
+
+        val result = client.uploadMultipleFiles(
+            files = listOf(FileUpload(file1Content), FileUpload(file2Content))
+        )
+
+        assertInstanceOf<NetworkResult.Success<UploadResponse>>(result)
+
+        wiremock.verify(
+            postRequestedFor(urlEqualTo("/files/upload-multiple"))
+                .withHeader("Content-Type", containing("multipart/form-data"))
+                .withRequestBody(containing("name=files"))
+                .withRequestBody(containing("File 1 content"))
+                .withRequestBody(containing("File 2 content"))
+        )
+    }
+
+    @Test
+    fun `single file upload uses custom filename when provided`() = runBlocking {
+        val expectedResponse = UploadResponse(id = "file-custom")
+
+        wiremock.stubFor(
+            post(urlEqualTo("/files/upload"))
+                .willReturn(
+                    ok()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(json.encodeToString(expectedResponse))
+                )
+        )
+
+        val client = FilesUploadClient(createHttpClient())
+        val fileContent = "PNG image bytes".toByteArray()
+        val result = client.uploadFile(
+            file = FileUpload(fileContent, "my-image.png")
+        )
+
+        assertInstanceOf<NetworkResult.Success<UploadResponse>>(result)
+
+        wiremock.verify(
+            postRequestedFor(urlEqualTo("/files/upload"))
+                .withHeader("Content-Type", containing("multipart/form-data"))
+                .withRequestBody(containing("name=file"))
+                .withRequestBody(containing("""filename="my-image.png""""))
+                .withRequestBody(containing("PNG image bytes"))
+        )
+    }
+
+    @Test
+    fun `multiple files upload uses custom filenames when provided`() = runBlocking {
+        val expectedResponse = UploadResponse(id = "file-multi-custom")
+
+        wiremock.stubFor(
+            post(urlEqualTo("/files/upload-multiple"))
+                .willReturn(
+                    ok()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(json.encodeToString(expectedResponse))
+                )
+        )
+
+        val client = FilesUploadMultipleClient(createHttpClient())
+        val file1Content = "PDF content 1".toByteArray()
+        val file2Content = "PDF content 2".toByteArray()
+
+        val result = client.uploadMultipleFiles(
+            files = listOf(
+                FileUpload(file1Content, "doc1.pdf"),
+                FileUpload(file2Content, "doc2.pdf")
+            )
+        )
+
+        assertInstanceOf<NetworkResult.Success<UploadResponse>>(result)
+
+        wiremock.verify(
+            postRequestedFor(urlEqualTo("/files/upload-multiple"))
+                .withHeader("Content-Type", containing("multipart/form-data"))
+                .withRequestBody(containing("name=files"))
+                .withRequestBody(containing("""filename="doc1.pdf""""))
+                .withRequestBody(containing("PDF content 1"))
+                .withRequestBody(containing("""filename="doc2.pdf""""))
+                .withRequestBody(containing("PDF content 2"))
+        )
+    }
+
+    @Test
+    fun `multiple files upload allows partial filename specification`() = runBlocking {
+        val expectedResponse = UploadResponse(id = "file-partial")
+
+        wiremock.stubFor(
+            post(urlEqualTo("/files/upload-multiple"))
+                .willReturn(
+                    ok()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(json.encodeToString(expectedResponse))
+                )
+        )
+
+        val client = FilesUploadMultipleClient(createHttpClient())
+        val file1Content = "File 1".toByteArray()
+        val file2Content = "File 2".toByteArray()
+
+        // Only provide filename for first file, second uses default
+        val result = client.uploadMultipleFiles(
+            files = listOf(
+                FileUpload(file1Content, "custom.txt"),
+                FileUpload(file2Content)  // Uses default filename
+            )
+        )
+
+        assertInstanceOf<NetworkResult.Success<UploadResponse>>(result)
+
+        wiremock.verify(
+            postRequestedFor(urlEqualTo("/files/upload-multiple"))
+                .withHeader("Content-Type", containing("multipart/form-data"))
+                .withRequestBody(containing("name=files"))
+                .withRequestBody(containing("""filename="custom.txt""""))
+                .withRequestBody(containing("File 1"))
+                .withRequestBody(containing("File 2"))
+        )
+    }
+}

--- a/end2end-tests/ktor/build.gradle.kts
+++ b/end2end-tests/ktor/build.gradle.kts
@@ -90,6 +90,12 @@ tasks {
         listOf("--serialization-library", "KOTLINX_SERIALIZATION")
     )
 
+    val generateKtorMultipartCode = createCodeGenerationTask(
+        "generateKtorMultipartCode",
+        "src/test/resources/examples/multipartFormData/api.yaml",
+        listOf("--base-package", "com.example.multipart")
+    )
+
     withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
         compilerOptions {
             optIn.add("kotlin.time.ExperimentalTime")
@@ -100,6 +106,7 @@ tasks {
         dependsOn(generateKtorInstantDateTimeCode)
         dependsOn(generateKtorQueryParametersCode)
         dependsOn(generateKtorPathParametersCode)
+        dependsOn(generateKtorMultipartCode)
     }
 
 
@@ -118,15 +125,21 @@ fun TaskContainer.createCodeGenerationTask(
     outputs.cacheIf { true }
     classpath = rootProject.files("./build/libs/fabrikt-${rootProject.version}.jar")
     mainClass.set("com.cjbooms.fabrikt.cli.CodeGen")
+    val basePackage = if (opts.contains("--base-package")) {
+        opts[opts.indexOf("--base-package") + 1]
+    } else {
+        "com.example"
+    }
+    val filteredOpts = opts.filterNot { it == "--base-package" || it == basePackage }
     args = listOf(
         "--output-directory", generationDir,
-        "--base-package", "com.example",
+        "--base-package", basePackage,
         "--api-file", apiFile,
         "--targets", "http_models",
         "--targets", "controllers",
         "--http-controller-target", "ktor",
         "--instant-library", "KOTLINX_INSTANT",
-    ) + opts
+    ) + filteredOpts
     dependsOn(":jar")
     dependsOn(":shadowJar")
 }

--- a/end2end-tests/ktor/src/test/kotlin/com/cjbooms/fabrikt/servers/ktor/KtorMultipartServerTest.kt
+++ b/end2end-tests/ktor/src/test/kotlin/com/cjbooms/fabrikt/servers/ktor/KtorMultipartServerTest.kt
@@ -1,0 +1,135 @@
+package com.cjbooms.fabrikt.servers.ktor
+
+import com.example.multipart.controllers.FilesUploadController.Companion.filesUploadRoutes
+import com.example.multipart.controllers.FilesUploadMultipleController.Companion.filesUploadMultipleRoutes
+import com.example.multipart.controllers.ReceivedFile
+import io.ktor.client.request.forms.formData
+import io.ktor.client.request.forms.submitFormWithBinaryData
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.Headers
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.jackson.jackson
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.plugins.statuspages.StatusPages
+import io.ktor.server.response.respondText
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import io.mockk.slot
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class KtorMultipartServerTest {
+
+    @Test
+    fun `single file upload is parsed correctly with file metadata`() {
+        val fileSlot = slot<ReceivedFile>()
+
+        testApplication {
+            configure()
+
+            routing {
+                filesUploadRoutes(FilesUploadControllerImpl(fileSlot))
+            }
+
+            val fileContent = "Hello, World!".toByteArray()
+
+            val response = client.submitFormWithBinaryData(
+                url = "/files/upload",
+                formData = formData {
+                    append("file", fileContent, Headers.build {
+                        append(HttpHeaders.ContentDisposition, "filename=\"test.txt\"")
+                        append(HttpHeaders.ContentType, "text/plain")
+                    })
+                }
+            )
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertThat(fileSlot.captured.content).isEqualTo(fileContent)
+            assertThat(fileSlot.captured.originalFileName).isEqualTo("test.txt")
+            assertThat(fileSlot.captured.contentType).isEqualTo(ContentType.Text.Plain)
+            assertThat(response.bodyAsText()).contains("file-123")
+        }
+    }
+
+    @Test
+    fun `multiple files upload is parsed correctly with file metadata`() {
+        val filesSlot = slot<List<ReceivedFile>>()
+
+        testApplication {
+            configure()
+
+            routing {
+                filesUploadMultipleRoutes(FilesUploadMultipleControllerImpl(filesSlot))
+            }
+
+            val file1Content = "File 1 content".toByteArray()
+            val file2Content = "File 2 content".toByteArray()
+
+            val response = client.submitFormWithBinaryData(
+                url = "/files/upload-multiple",
+                formData = formData {
+                    append("files", file1Content, Headers.build {
+                        append(HttpHeaders.ContentDisposition, "filename=\"file1.txt\"")
+                        append(HttpHeaders.ContentType, "text/plain")
+                    })
+                    append("files", file2Content, Headers.build {
+                        append(HttpHeaders.ContentDisposition, "filename=\"file2.pdf\"")
+                        append(HttpHeaders.ContentType, "application/pdf")
+                    })
+                }
+            )
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertThat(filesSlot.captured).hasSize(2)
+            assertThat(filesSlot.captured[0].content).isEqualTo(file1Content)
+            assertThat(filesSlot.captured[0].originalFileName).isEqualTo("file1.txt")
+            assertThat(filesSlot.captured[0].contentType).isEqualTo(ContentType.Text.Plain)
+            assertThat(filesSlot.captured[1].content).isEqualTo(file2Content)
+            assertThat(filesSlot.captured[1].originalFileName).isEqualTo("file2.pdf")
+            assertThat(filesSlot.captured[1].contentType).isEqualTo(ContentType.Application.Pdf)
+        }
+    }
+
+    @Test
+    fun `single file upload returns bad request when required file is missing`() {
+        val fileSlot = slot<ReceivedFile>()
+
+        testApplication {
+            configureWithStatusPages()
+
+            routing {
+                filesUploadRoutes(FilesUploadControllerImpl(fileSlot))
+            }
+
+            val response = client.submitFormWithBinaryData(
+                url = "/files/upload",
+                formData = formData {
+                    append("other", "some value")
+                }
+            )
+
+            assertEquals(HttpStatusCode.BadRequest, response.status)
+            assertThat(response.bodyAsText()).contains("Missing required multipart part: file")
+        }
+    }
+
+    private fun ApplicationTestBuilder.configure() {
+        install(ContentNegotiation) {
+            jackson()
+        }
+    }
+
+    private fun ApplicationTestBuilder.configureWithStatusPages() {
+        install(ContentNegotiation) {
+            jackson()
+        }
+        install(StatusPages) {
+            exception<io.ktor.server.plugins.BadRequestException> { call, cause ->
+                call.respondText(cause.message ?: "Bad Request", status = HttpStatusCode.BadRequest)
+            }
+        }
+    }
+}

--- a/end2end-tests/ktor/src/test/kotlin/com/cjbooms/fabrikt/servers/ktor/MultipartControllerImpl.kt
+++ b/end2end-tests/ktor/src/test/kotlin/com/cjbooms/fabrikt/servers/ktor/MultipartControllerImpl.kt
@@ -1,0 +1,30 @@
+package com.cjbooms.fabrikt.servers.ktor
+
+import com.example.multipart.controllers.FilesUploadController
+import com.example.multipart.controllers.FilesUploadMultipleController
+import com.example.multipart.controllers.ReceivedFile
+import com.example.multipart.controllers.TypedApplicationCall
+import com.example.multipart.models.UploadResponse
+import io.mockk.CapturingSlot
+
+class FilesUploadControllerImpl(
+    private val fileSlot: CapturingSlot<ReceivedFile>,
+) : FilesUploadController {
+    override suspend fun uploadFile(file: ReceivedFile, call: TypedApplicationCall<UploadResponse>) {
+        fileSlot.captured = file
+        call.respondTyped(
+            UploadResponse(id = "file-123")
+        )
+    }
+}
+
+class FilesUploadMultipleControllerImpl(
+    private val filesSlot: CapturingSlot<List<ReceivedFile>>,
+) : FilesUploadMultipleController {
+    override suspend fun uploadMultipleFiles(files: List<ReceivedFile>, call: TypedApplicationCall<UploadResponse>) {
+        filesSlot.captured = files
+        call.respondTyped(
+            UploadResponse(id = "file-multi")
+        )
+    }
+}

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/KtorControllerInterfaceGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/KtorControllerInterfaceGenerator.kt
@@ -16,6 +16,7 @@ import com.cjbooms.fabrikt.model.HeaderParam
 import com.cjbooms.fabrikt.model.IncomingParameter
 import com.cjbooms.fabrikt.model.KotlinTypeInfo
 import com.cjbooms.fabrikt.model.KotlinTypes
+import com.cjbooms.fabrikt.model.MultipartParameter
 import com.cjbooms.fabrikt.model.PathParam
 import com.cjbooms.fabrikt.model.QueryParam
 import com.cjbooms.fabrikt.model.RequestParameter
@@ -40,10 +41,12 @@ import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.TypeVariableName
+import com.squareup.kotlinpoet.asClassName
 import com.squareup.kotlinpoet.asTypeName
 import kotlin.reflect.KClass
 
 private const val TYPED_APPLICATION_CALL_CLASS_NAME = "TypedApplicationCall"
+private const val RECEIVED_FILE_CLASS_NAME = "ReceivedFile"
 
 /**
  * Generates controller interface and routing functions for Ktor.
@@ -140,6 +143,26 @@ class KtorControllerInterfaceGenerator(
 
         bodyParams.forEach { param ->
             builder.addParameter(param.toParameterSpecBuilder().build())
+        }
+
+        // Handle multipart parameters
+        val multipartParams = params.filterIsInstance<MultipartParameter>()
+        multipartParams.forEach { param ->
+            // Use ReceivedFile for file types - wraps content with originalFileName and contentType metadata
+            val receivedFileType = ClassName(packages.controllers, RECEIVED_FILE_CLASS_NAME)
+            val fileType = if (param.schema.type == "array") {
+                List::class.asClassName().parameterizedBy(receivedFileType)
+            } else {
+                receivedFileType
+            }
+
+            val paramType = if (param.isFile) {
+                if (param.isRequired) fileType else fileType.copy(nullable = true)
+            } else {
+                param.type
+            }
+
+            builder.addParameter(ParameterSpec.builder(param.name, paramType).build())
         }
 
         builder.addKdoc(buildControllerFunKdoc(operation, params))
@@ -260,8 +283,14 @@ class KtorControllerInterfaceGenerator(
             )
         }
 
+        // Handle multipart parameters
+        val multipartParams = params.filterIsInstance<MultipartParameter>()
+        if (multipartParams.isNotEmpty()) {
+            addMultipartHandling(builder, multipartParams)
+        }
+
         val methodParameters =
-            listOf(headerParams, pathParams, queryParams, bodyParams).asSequence().flatten().map { it.name }
+            listOf(headerParams, pathParams, queryParams, bodyParams, multipartParams).asSequence().flatten().map { it.name }
                 .joinToString(", ")
 
         if (operation.happyPathResponse(packages.base).isUnit()) {
@@ -292,6 +321,91 @@ class KtorControllerInterfaceGenerator(
         }
 
         return builder.build()
+    }
+
+    private fun addMultipartHandling(builder: CodeBlock.Builder, multipartParams: List<MultipartParameter>) {
+        val partDataFileItem = ClassName("io.ktor.http.content", "PartData", "FileItem")
+        val partDataFormItem = ClassName("io.ktor.http.content", "PartData", "FormItem")
+        val receivedFileType = ClassName(packages.controllers, RECEIVED_FILE_CLASS_NAME)
+        val readRemainingFun = MemberName("io.ktor.utils.io", "readRemaining")
+        val readByteArrayFun = MemberName("kotlinx.io", "readByteArray")
+
+        builder.addStatement(
+            "val multipartData = %M.%M()",
+            MemberName("io.ktor.server.application", "call"),
+            MemberName("io.ktor.server.request", "receiveMultipart"),
+        )
+
+        // Initialize variables for each multipart parameter
+        // For files, use ReceivedFile - wraps content with originalFileName and contentType metadata
+        for (param in multipartParams) {
+            if (param.isFile) {
+                if (param.schema.type == "array") {
+                    builder.addStatement("val ${param.name}Parts = mutableListOf<%T>()", receivedFileType)
+                } else {
+                    builder.addStatement("var ${param.name}Received: %T? = null", receivedFileType)
+                }
+            } else {
+                builder.addStatement("var ${param.name}Value: %T? = null", String::class)
+            }
+        }
+
+        // Process multipart data - read file content immediately as Ktor 3.0 disposes parts after iteration
+        val forEachPartFun = MemberName("io.ktor.http.content", "forEachPart")
+        builder.addStatement("multipartData.%M { part ->", forEachPartFun)
+        builder.indent()
+        builder.addStatement("when (part.name) {")
+        builder.indent()
+
+        for (param in multipartParams) {
+            if (param.isFile) {
+                if (param.schema.type == "array") {
+                    builder.addStatement(
+                        "%S -> if (part is %T) ${param.name}Parts.add(%T(part.provider().%M().%M(), part.originalFileName, part.contentType))",
+                        param.oasName, partDataFileItem, receivedFileType, readRemainingFun, readByteArrayFun
+                    )
+                } else {
+                    builder.addStatement(
+                        "%S -> if (part is %T) ${param.name}Received = %T(part.provider().%M().%M(), part.originalFileName, part.contentType)",
+                        param.oasName, partDataFileItem, receivedFileType, readRemainingFun, readByteArrayFun
+                    )
+                }
+            } else {
+                builder.addStatement("%S -> if (part is %T) ${param.name}Value = part.value", param.oasName, partDataFormItem)
+            }
+        }
+
+        builder.unindent()
+        builder.addStatement("}")
+        builder.unindent()
+        builder.addStatement("}")
+
+        // Assign final values
+        for (param in multipartParams) {
+            if (param.isFile) {
+                if (param.schema.type == "array") {
+                    builder.addStatement("val ${param.name} = ${param.name}Parts.toList()")
+                } else {
+                    if (param.isRequired) {
+                        builder.addStatement("val ${param.name} = ${param.name}Received ?: throw %M(%S)",
+                            MemberName("io.ktor.server.plugins", "BadRequestException"),
+                            "Missing required multipart part: ${param.oasName}"
+                        )
+                    } else {
+                        builder.addStatement("val ${param.name} = ${param.name}Received")
+                    }
+                }
+            } else {
+                if (param.isRequired) {
+                    builder.addStatement("val ${param.name} = ${param.name}Value ?: throw %M(%S)",
+                        MemberName("io.ktor.server.plugins", "BadRequestException"),
+                        "Missing required multipart part: ${param.oasName}"
+                    )
+                } else {
+                    builder.addStatement("val ${param.name} = ${param.name}Value")
+                }
+            }
+        }
     }
 
     private fun buildControllerFunKdoc(operation: Operation, parameters: List<IncomingParameter>): CodeBlock {
@@ -330,9 +444,23 @@ class KtorControllerInterfaceGenerator(
         return kDoc.build()
     }
 
-    override fun generateLibrary(): Collection<ControllerLibraryType> = setOf(
-        buildTypedApplicationCall(),
-    )
+    override fun generateLibrary(): Collection<ControllerLibraryType> = buildSet {
+        add(buildTypedApplicationCall())
+        if (hasFileMultipartParameters()) {
+            add(buildReceivedFileClass())
+        }
+    }
+
+    private fun hasFileMultipartParameters(): Boolean =
+        api.openApi3.routeToPaths().any { (_, paths) ->
+            paths.any { path ->
+                path.value.operations.any { (_, operation) ->
+                    operation.toIncomingParameters(packages.base, path.value.parameters, emptyList())
+                        .filterIsInstance<MultipartParameter>()
+                        .any { it.isFile }
+                }
+            }
+        }
 
     /**
      * Builds a typed ApplicationCall that provides type safe variants of the respond functions.
@@ -410,6 +538,57 @@ class KtorControllerInterfaceGenerator(
                             )
                             .build()
                     )
+                    .build()
+            )
+            .build()
+
+        return ControllerLibraryType(spec, packages.base)
+    }
+
+    /**
+     * Builds a data class to wrap received file content with metadata from multipart uploads.
+     */
+    private fun buildReceivedFileClass(): ControllerLibraryType {
+        val contentType = ClassName("io.ktor.http", "ContentType")
+
+        val spec = TypeSpec.classBuilder(RECEIVED_FILE_CLASS_NAME)
+            .addModifiers(KModifier.DATA)
+            .primaryConstructor(
+                FunSpec.constructorBuilder()
+                    .addParameter("content", ByteArray::class)
+                    .addParameter(
+                        ParameterSpec.builder("originalFileName", String::class.asTypeName().copy(nullable = true))
+                            .defaultValue("null")
+                            .build()
+                    )
+                    .addParameter(
+                        ParameterSpec.builder("contentType", contentType.copy(nullable = true))
+                            .defaultValue("null")
+                            .build()
+                    )
+                    .build()
+            )
+            .addProperty(
+                PropertySpec.builder("content", ByteArray::class)
+                    .initializer("content")
+                    .build()
+            )
+            .addProperty(
+                PropertySpec.builder("originalFileName", String::class.asTypeName().copy(nullable = true))
+                    .initializer("originalFileName")
+                    .build()
+            )
+            .addProperty(
+                PropertySpec.builder("contentType", contentType.copy(nullable = true))
+                    .initializer("contentType")
+                    .build()
+            )
+            .addKdoc(
+                CodeBlock.builder()
+                    .add("Wrapper for received file content from multipart uploads.\n\n")
+                    .add("@property content The raw file content as a byte array\n")
+                    .add("@property originalFileName The original filename from the Content-Disposition header, if provided\n")
+                    .add("@property contentType The content type of the file, if provided\n")
                     .build()
             )
             .build()

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/MicronautControllerInterfaceGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/MicronautControllerInterfaceGenerator.kt
@@ -17,6 +17,7 @@ import com.cjbooms.fabrikt.model.ControllerLibraryType
 import com.cjbooms.fabrikt.model.ControllerType
 import com.cjbooms.fabrikt.model.HeaderParam
 import com.cjbooms.fabrikt.model.KotlinTypes
+import com.cjbooms.fabrikt.model.MultipartParameter
 import com.cjbooms.fabrikt.model.PathParam
 import com.cjbooms.fabrikt.model.QueryParam
 import com.cjbooms.fabrikt.model.RequestParameter
@@ -111,6 +112,9 @@ class MicronautControllerInterfaceGenerator(
                             .addValidationAnnotations(it)
                             .addMicronautParamAnnotation(it)
                             .build()
+
+                    is MultipartParameter ->
+                        error("Multipart parameters not yet supported for Micronaut")
                 }
             }
             .forEach { funcSpec.addParameter(it) }

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/SpringControllerInterfaceGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/SpringControllerInterfaceGenerator.kt
@@ -16,6 +16,7 @@ import com.cjbooms.fabrikt.model.ControllerType
 import com.cjbooms.fabrikt.model.HeaderParam
 import com.cjbooms.fabrikt.model.KotlinTypeInfo
 import com.cjbooms.fabrikt.model.KotlinTypes
+import com.cjbooms.fabrikt.model.MultipartParameter
 import com.cjbooms.fabrikt.model.PathParam
 import com.cjbooms.fabrikt.model.QueryParam
 import com.cjbooms.fabrikt.model.RequestParameter
@@ -109,6 +110,9 @@ class SpringControllerInterfaceGenerator(
                             .addValidationAnnotations(it)
                             .addSpringParamAnnotation(it)
                             .build()
+
+                    is MultipartParameter ->
+                        error("Multipart parameters not yet supported for Spring")
                 }
             }
             .forEach { funcSpec.addParameter(it) }

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/model/ModelGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/model/ModelGenerator.kt
@@ -85,6 +85,7 @@ class ModelGenerator(
             basePackage: String,
             typeInfo: KotlinTypeInfo,
             isNullable: Boolean = false,
+            applySerializationAnnotations: Boolean = true,
         ): TypeName {
             val className =
                 toClassName(
@@ -96,10 +97,15 @@ class ModelGenerator(
                     val elementType = toModelType(
                         basePackage,
                         typeInfo.parameterizedType,
-                        typeInfo.isParameterizedTypeNullable
+                        typeInfo.isParameterizedTypeNullable,
+                        applySerializationAnnotations
                     )
-                    val annotatedElementType = MutableSettings.serializationLibrary.serializationAnnotations
-                        .annotateArrayElementType(elementType, typeInfo.parameterizedType)
+                    val annotatedElementType = if (applySerializationAnnotations) {
+                        MutableSettings.serializationLibrary.serializationAnnotations
+                            .annotateArrayElementType(elementType, typeInfo.parameterizedType)
+                    } else {
+                        elementType
+                    }
                     if (typeInfo.hasUniqueItems) {
                         createSet(annotatedElementType)
                     } else {

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinGenModels.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinGenModels.kt
@@ -83,6 +83,16 @@ sealed class IncomingParameter(val oasName: String, val description: String?, va
 class BodyParameter(oasName: String, description: String?, type: TypeName, val schema: Schema) :
     IncomingParameter(oasName, description, type)
 
+class MultipartParameter(
+    oasName: String,
+    description: String?,
+    type: TypeName,
+    val schema: Schema,
+    val isFile: Boolean,
+    val isRequired: Boolean,
+    val contentType: String? = null,
+) : IncomingParameter(oasName, description, type)
+
 class RequestParameter(
     oasName: String,
     description: String?,

--- a/src/main/resources/templates/client-code/api-models.kt.hbs
+++ b/src/main/resources/templates/client-code/api-models.kt.hbs
@@ -10,6 +10,14 @@ import okhttp3.Headers
 data class ApiResponse<T>(val statusCode: Int, val headers: Headers, val data: T? = null)
 
 /**
+ * Represents a file upload with optional filename.
+ *
+ * @param content The file content as a byte array
+ * @param filename Optional filename to use in the Content-Disposition header
+ */
+data class FileUpload(val content: ByteArray, val filename: String? = null)
+
+/**
  * API non-2xx failure responses returned by API call.
  */
 open class ApiException(override val message: String) : RuntimeException(message)

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/KtorClientGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/KtorClientGeneratorTest.kt
@@ -25,6 +25,7 @@ class KtorClientGeneratorTest {
     private fun fullApiTestCases(): Stream<String> = Stream.of(
         "ktorClient",
         "parameterNameClash",
+        "multipartFormData",
     )
 
     @BeforeEach

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/KtorControllerInterfaceGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/KtorControllerInterfaceGeneratorTest.kt
@@ -45,6 +45,7 @@ class KtorControllerInterfaceGeneratorTest {
         "modelSuffix",
         "queryParameters",
         "pathParameters",
+        "multipartFormData",
     )
 
     private fun setupGithubApiTestEnv() {

--- a/src/test/resources/examples/fileComment/controllers/ktor/ReceivedFile.kt
+++ b/src/test/resources/examples/fileComment/controllers/ktor/ReceivedFile.kt
@@ -1,0 +1,23 @@
+//
+// This file was generated from an OpenAPI specification by Fabrikt.
+// DO NOT EDIT. Any changes will be overwritten the next time the code is generated.
+// To update, modify the specification and re-generate.
+//
+package examples.fileComment.controllers
+
+import io.ktor.http.ContentType
+import kotlin.ByteArray
+import kotlin.String
+
+/**
+ * Wrapper for received file content from multipart uploads.
+ *
+ * @property content The raw file content as a byte array
+ * @property originalFileName The original filename from the Content-Disposition header, if provided
+ * @property contentType The content type of the file, if provided
+ */
+public data class ReceivedFile(
+  public val content: ByteArray,
+  public val originalFileName: String? = null,
+  public val contentType: ContentType? = null,
+)

--- a/src/test/resources/examples/ktorClient/client/ktor/KtorApiModels.kt
+++ b/src/test/resources/examples/ktorClient/client/ktor/KtorApiModels.kt
@@ -54,3 +54,11 @@ sealed interface NetworkResult<out T> {
      */
     data class Failure(val error: NetworkError) : NetworkResult<Nothing>
 }
+
+/**
+ * Represents a file upload with optional filename.
+ *
+ * @param content The file content as a byte array
+ * @param filename Optional filename to use in the Content-Disposition header
+ */
+data class FileUpload(val content: ByteArray, val filename: String? = null)

--- a/src/test/resources/examples/multipartFormData/api.yaml
+++ b/src/test/resources/examples/multipartFormData/api.yaml
@@ -1,0 +1,66 @@
+openapi: 3.0.3
+info:
+  title: Multipart Form Data API
+  description: API for testing multipart/form-data support
+  version: 1.0.0
+paths:
+  /files/upload:
+    post:
+      operationId: uploadFile
+      summary: Upload a single file
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - file
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: The file to upload
+      responses:
+        '200':
+          description: File uploaded successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UploadResponse'
+  /files/upload-multiple:
+    post:
+      operationId: uploadMultipleFiles
+      summary: Upload multiple files
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - files
+              properties:
+                files:
+                  type: array
+                  items:
+                    type: string
+                    format: binary
+                  description: The files to upload
+      responses:
+        '200':
+          description: Files uploaded successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UploadResponse'
+components:
+  schemas:
+    UploadResponse:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+          description: Unique identifier for the uploaded file

--- a/src/test/resources/examples/multipartFormData/client/ktor/KtorApiModels.kt
+++ b/src/test/resources/examples/multipartFormData/client/ktor/KtorApiModels.kt
@@ -1,4 +1,4 @@
-package {{ client }}
+package examples.multipartFormData.client
 
 import java.io.IOException
 

--- a/src/test/resources/examples/multipartFormData/client/ktor/KtorClient.kt
+++ b/src/test/resources/examples/multipartFormData/client/ktor/KtorClient.kt
@@ -1,0 +1,157 @@
+package examples.multipartFormData.client
+
+import examples.multipartFormData.models.UploadResponse
+import io.ktor.client.HttpClient
+import io.ktor.client.call.NoTransformationFoundException
+import io.ktor.client.call.body
+import io.ktor.client.plugins.ResponseException
+import io.ktor.client.request.forms.MultiPartFormDataContent
+import io.ktor.client.request.forms.append
+import io.ktor.client.request.forms.formData
+import io.ktor.client.request.`header`
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.headersOf
+import io.ktor.http.isSuccess
+import io.ktor.serialization.ContentConvertException
+import kotlinx.coroutines.CancellationException
+import java.io.IOException
+import kotlin.collections.List
+
+public class FilesUploadClient(
+    private val httpClient: HttpClient,
+) {
+    /**
+     * Upload a single file
+     *
+     * Parameters:
+     *
+     * Returns:
+     * 	[NetworkResult.Success] with [examples.multipartFormData.models.UploadResponse] if the request
+     * was successful.
+     * 	[NetworkResult.Failure] with a [NetworkError] if the request failed.
+     */
+    public suspend fun uploadFile(`file`: FileUpload): NetworkResult<UploadResponse> {
+        val url = """/files/upload"""
+
+        return try {
+            val response =
+                httpClient.post(url) {
+                    `header`("Accept", "application/json")
+                    setBody(
+                        MultiPartFormDataContent(
+                            formData {
+                                val fileFilenameValue = `file`.filename ?: "file"
+                                append(
+                                    "file",
+                                    `file`.content,
+                                    headersOf(
+                                        HttpHeaders.ContentDisposition,
+                                        """filename="$fileFilenameValue"""",
+                                    ),
+                                )
+                            },
+                        ),
+                    )
+                }
+
+            if (response.status.isSuccess()) {
+                NetworkResult.Success(response.body())
+            } else {
+                val errorBody = response.bodyAsText().ifBlank { null }
+                NetworkResult.Failure(
+                    NetworkError.Http(
+                        statusCode = response.status.value,
+                        statusDescription = response.status.description,
+                        body = errorBody,
+                    ),
+                )
+            }
+        } catch (e: ResponseException) {
+            val status = e.response.status
+            val body = runCatching { e.response.bodyAsText() }.getOrNull()?.ifBlank { null }
+            NetworkResult.Failure(NetworkError.Http(status.value, status.description, body))
+        } catch (e: IOException) {
+            NetworkResult.Failure(NetworkError.Network(e))
+        } catch (e: ContentConvertException) {
+            NetworkResult.Failure(NetworkError.Serialization(e))
+        } catch (e: NoTransformationFoundException) {
+            NetworkResult.Failure(NetworkError.Serialization(e))
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            NetworkResult.Failure(NetworkError.Unknown(e))
+        }
+    }
+}
+
+public class FilesUploadMultipleClient(
+    private val httpClient: HttpClient,
+) {
+    /**
+     * Upload multiple files
+     *
+     * Parameters:
+     *
+     * Returns:
+     * 	[NetworkResult.Success] with [examples.multipartFormData.models.UploadResponse] if the request
+     * was successful.
+     * 	[NetworkResult.Failure] with a [NetworkError] if the request failed.
+     */
+    public suspend fun uploadMultipleFiles(files: List<FileUpload>): NetworkResult<UploadResponse> {
+        val url = """/files/upload-multiple"""
+
+        return try {
+            val response =
+                httpClient.post(url) {
+                    `header`("Accept", "application/json")
+                    setBody(
+                        MultiPartFormDataContent(
+                            formData {
+                                files.forEachIndexed { index, fileUpload ->
+                                    val filename = fileUpload.filename ?: "files" + "_" + index
+                                    append(
+                                        "files",
+                                        fileUpload.content,
+                                        headersOf(
+                                            HttpHeaders.ContentDisposition,
+                                            """filename="$filename"""",
+                                        ),
+                                    )
+                                }
+                            },
+                        ),
+                    )
+                }
+
+            if (response.status.isSuccess()) {
+                NetworkResult.Success(response.body())
+            } else {
+                val errorBody = response.bodyAsText().ifBlank { null }
+                NetworkResult.Failure(
+                    NetworkError.Http(
+                        statusCode = response.status.value,
+                        statusDescription = response.status.description,
+                        body = errorBody,
+                    ),
+                )
+            }
+        } catch (e: ResponseException) {
+            val status = e.response.status
+            val body = runCatching { e.response.bodyAsText() }.getOrNull()?.ifBlank { null }
+            NetworkResult.Failure(NetworkError.Http(status.value, status.description, body))
+        } catch (e: IOException) {
+            NetworkResult.Failure(NetworkError.Network(e))
+        } catch (e: ContentConvertException) {
+            NetworkResult.Failure(NetworkError.Serialization(e))
+        } catch (e: NoTransformationFoundException) {
+            NetworkResult.Failure(NetworkError.Serialization(e))
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            NetworkResult.Failure(NetworkError.Unknown(e))
+        }
+    }
+}

--- a/src/test/resources/examples/multipartFormData/controllers/ktor/Controllers.kt
+++ b/src/test/resources/examples/multipartFormData/controllers/ktor/Controllers.kt
@@ -1,0 +1,286 @@
+package examples.multipartFormData.controllers
+
+import examples.multipartFormData.models.UploadResponse
+import io.ktor.http.ContentType
+import io.ktor.http.Headers
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.Parameters
+import io.ktor.http.content.PartData
+import io.ktor.http.content.forEachPart
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.application.call
+import io.ktor.server.plugins.BadRequestException
+import io.ktor.server.plugins.MissingRequestParameterException
+import io.ktor.server.plugins.ParameterConversionException
+import io.ktor.server.request.receiveMultipart
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.post
+import io.ktor.util.converters.ConversionService
+import io.ktor.util.converters.DefaultConversionService
+import io.ktor.util.reflect.typeInfo
+import io.ktor.utils.io.readRemaining
+import kotlinx.io.readByteArray
+import kotlin.Any
+import kotlin.ByteArray
+import kotlin.String
+import kotlin.Suppress
+import kotlin.collections.List
+
+public interface FilesUploadController {
+    /**
+     * Upload a single file
+     *
+     * Route is expected to respond with [examples.multipartFormData.models.UploadResponse].
+     * Use [examples.multipartFormData.controllers.TypedApplicationCall.respondTyped] to send the
+     * response.
+     *
+     * @param file The file to upload
+     * @param call Decorated ApplicationCall with additional typed respond methods
+     */
+    public suspend fun uploadFile(
+        `file`: ReceivedFile,
+        call: TypedApplicationCall<UploadResponse>,
+    )
+
+    public companion object {
+        /**
+         * Mounts all routes for the FilesUpload resource
+         *
+         * - POST /files/upload Upload a single file
+         */
+        public fun Route.filesUploadRoutes(controller: FilesUploadController) {
+            post("/files/upload") {
+                val multipartData = call.receiveMultipart()
+                var fileReceived: ReceivedFile? = null
+                multipartData.forEachPart { part ->
+                    when (part.name) {
+                        "file" ->
+                            if (part is PartData.FileItem) {
+                                fileReceived =
+                                    ReceivedFile(
+                                        part.provider().readRemaining().readByteArray(),
+                                        part.originalFileName,
+                                        part.contentType,
+                                    )
+                            }
+                    }
+                }
+                val file =
+                    fileReceived ?: throw
+                        BadRequestException("Missing required multipart part: file")
+                controller.uploadFile(file, TypedApplicationCall(call))
+            }
+        }
+
+        /**
+         * Gets parameter value associated with this name or null if the name is not present.
+         * Converting to type R using ConversionService.
+         *
+         * Throws:
+         *   ParameterConversionException - when conversion from String to R fails
+         */
+        private inline fun <reified R : Any> Parameters.getTyped(
+            name: String,
+            conversionService: ConversionService = DefaultConversionService,
+        ): R? {
+            val values = getAll(name) ?: return null
+            val typeInfo = typeInfo<R>()
+            return try {
+                @Suppress("UNCHECKED_CAST")
+                conversionService.fromValues(values, typeInfo) as R
+            } catch (cause: Exception) {
+                throw ParameterConversionException(
+                    name,
+                    typeInfo.type.simpleName
+                        ?: typeInfo.type.toString(),
+                    cause,
+                )
+            }
+        }
+
+        /**
+         * Gets parameter value associated with this name or throws if the name is not present.
+         * Converting to type R using ConversionService.
+         *
+         * Throws:
+         *   MissingRequestParameterException - when parameter is missing
+         *   ParameterConversionException - when conversion from String to R fails
+         */
+        private inline fun <reified R : Any> Parameters.getTypedOrFail(
+            name: String,
+            conversionService: ConversionService = DefaultConversionService,
+        ): R {
+            val values = getAll(name) ?: throw MissingRequestParameterException(name)
+            val typeInfo = typeInfo<R>()
+            return try {
+                @Suppress("UNCHECKED_CAST")
+                conversionService.fromValues(values, typeInfo) as R
+            } catch (cause: Exception) {
+                throw ParameterConversionException(
+                    name,
+                    typeInfo.type.simpleName
+                        ?: typeInfo.type.toString(),
+                    cause,
+                )
+            }
+        }
+
+        /**
+         * Gets first value from the list of values associated with a name.
+         *
+         * Throws:
+         *   BadRequestException - when the name is not present
+         */
+        private fun Headers.getOrFail(name: String): String =
+            this[name] ?: throw
+                BadRequestException("Header " + name + " is required")
+    }
+}
+
+public interface FilesUploadMultipleController {
+    /**
+     * Upload multiple files
+     *
+     * Route is expected to respond with [examples.multipartFormData.models.UploadResponse].
+     * Use [examples.multipartFormData.controllers.TypedApplicationCall.respondTyped] to send the
+     * response.
+     *
+     * @param files The files to upload
+     * @param call Decorated ApplicationCall with additional typed respond methods
+     */
+    public suspend fun uploadMultipleFiles(
+        files: List<ReceivedFile>,
+        call: TypedApplicationCall<UploadResponse>,
+    )
+
+    public companion object {
+        /**
+         * Mounts all routes for the FilesUploadMultiple resource
+         *
+         * - POST /files/upload-multiple Upload multiple files
+         */
+        public fun Route.filesUploadMultipleRoutes(controller: FilesUploadMultipleController) {
+            post("/files/upload-multiple") {
+                val multipartData = call.receiveMultipart()
+                val filesParts = mutableListOf<ReceivedFile>()
+                multipartData.forEachPart { part ->
+                    when (part.name) {
+                        "files" ->
+                            if (part is PartData.FileItem) {
+                                filesParts.add(
+                                    ReceivedFile(
+                                        part.provider().readRemaining().readByteArray(),
+                                        part.originalFileName,
+                                        part.contentType,
+                                    ),
+                                )
+                            }
+                    }
+                }
+                val files = filesParts.toList()
+                controller.uploadMultipleFiles(files, TypedApplicationCall(call))
+            }
+        }
+
+        /**
+         * Gets parameter value associated with this name or null if the name is not present.
+         * Converting to type R using ConversionService.
+         *
+         * Throws:
+         *   ParameterConversionException - when conversion from String to R fails
+         */
+        private inline fun <reified R : Any> Parameters.getTyped(
+            name: String,
+            conversionService: ConversionService = DefaultConversionService,
+        ): R? {
+            val values = getAll(name) ?: return null
+            val typeInfo = typeInfo<R>()
+            return try {
+                @Suppress("UNCHECKED_CAST")
+                conversionService.fromValues(values, typeInfo) as R
+            } catch (cause: Exception) {
+                throw ParameterConversionException(
+                    name,
+                    typeInfo.type.simpleName
+                        ?: typeInfo.type.toString(),
+                    cause,
+                )
+            }
+        }
+
+        /**
+         * Gets parameter value associated with this name or throws if the name is not present.
+         * Converting to type R using ConversionService.
+         *
+         * Throws:
+         *   MissingRequestParameterException - when parameter is missing
+         *   ParameterConversionException - when conversion from String to R fails
+         */
+        private inline fun <reified R : Any> Parameters.getTypedOrFail(
+            name: String,
+            conversionService: ConversionService = DefaultConversionService,
+        ): R {
+            val values = getAll(name) ?: throw MissingRequestParameterException(name)
+            val typeInfo = typeInfo<R>()
+            return try {
+                @Suppress("UNCHECKED_CAST")
+                conversionService.fromValues(values, typeInfo) as R
+            } catch (cause: Exception) {
+                throw ParameterConversionException(
+                    name,
+                    typeInfo.type.simpleName
+                        ?: typeInfo.type.toString(),
+                    cause,
+                )
+            }
+        }
+
+        /**
+         * Gets first value from the list of values associated with a name.
+         *
+         * Throws:
+         *   BadRequestException - when the name is not present
+         */
+        private fun Headers.getOrFail(name: String): String =
+            this[name] ?: throw
+                BadRequestException("Header " + name + " is required")
+    }
+}
+
+/**
+ * Decorator for Ktor's ApplicationCall that provides type safe variants of the [respond] functions.
+ *
+ * It can be used as a drop-in replacement for [io.ktor.server.application.ApplicationCall].
+ *
+ * @param R The type of the response body
+ */
+public class TypedApplicationCall<R : Any>(
+    private val applicationCall: ApplicationCall,
+) : ApplicationCall by applicationCall {
+    @Suppress("unused")
+    public suspend inline fun <reified T : R> respondTyped(message: T) {
+        respond(message)
+    }
+
+    @Suppress("unused")
+    public suspend inline fun <reified T : R> respondTyped(
+        status: HttpStatusCode,
+        message: T,
+    ) {
+        respond(status, message)
+    }
+}
+
+/**
+ * Wrapper for received file content from multipart uploads.
+ *
+ * @property content The raw file content as a byte array
+ * @property originalFileName The original filename from the Content-Disposition header, if provided
+ * @property contentType The content type of the file, if provided
+ */
+public data class ReceivedFile(
+    public val content: ByteArray,
+    public val originalFileName: String? = null,
+    public val contentType: ContentType? = null,
+)

--- a/src/test/resources/examples/multipartFormData/models/ClientModels.kt
+++ b/src/test/resources/examples/multipartFormData/models/ClientModels.kt
@@ -1,0 +1,15 @@
+package examples.multipartFormData.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import javax.validation.constraints.NotNull
+import kotlin.String
+
+public data class UploadResponse(
+    /**
+     * Unique identifier for the uploaded file
+     */
+    @param:JsonProperty("id")
+    @get:JsonProperty("id")
+    @get:NotNull
+    public val id: String,
+)

--- a/src/test/resources/examples/parameterNameClash/client/ktor/KtorApiModels.kt
+++ b/src/test/resources/examples/parameterNameClash/client/ktor/KtorApiModels.kt
@@ -54,3 +54,11 @@ sealed interface NetworkResult<out T> {
      */
     data class Failure(val error: NetworkError) : NetworkResult<Nothing>
 }
+
+/**
+ * Represents a file upload with optional filename.
+ *
+ * @param content The file content as a byte array
+ * @param filename Optional filename to use in the Content-Disposition header
+ */
+data class FileUpload(val content: ByteArray, val filename: String? = null)


### PR DESCRIPTION
## Summary
- Introduces core multipart handling with new `MultipartParameter` model and generator utilities
- Implements multipart file upload for Ktor client using `MultiPartFormDataContent`
- Implements multipart file upload for Ktor server controller using `ReceivedFile` wrapper for file metadata

This PR contains the core/shared changes that other multipart PRs depend on.