### PR TITLE
Add multipart/form-data support for Spring client and server

### DIFF
--- a/end2end-tests/spring/build.gradle.kts
+++ b/end2end-tests/spring/build.gradle.kts
@@ -1,0 +1,82 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+val generationDir = "$buildDir/generated"
+
+sourceSets {
+    main { java.srcDirs("$generationDir/src/main/kotlin") }
+    test { java.srcDirs("$generationDir/src/test/kotlin") }
+}
+
+plugins {
+    kotlin("jvm")
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+val jacksonVersion: String by rootProject.extra
+val junitVersion: String by rootProject.extra
+val springBootVersion = "3.4.3"
+
+dependencies {
+    implementation(platform("com.fasterxml.jackson:jackson-bom:$jacksonVersion"))
+    implementation("jakarta.validation:jakarta.validation-api:3.0.2")
+    implementation("javax.validation:validation-api:2.0.1.Final")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+    implementation("com.fasterxml.jackson.core:jackson-databind")
+    implementation("com.fasterxml.jackson.core:jackson-core")
+    implementation("com.fasterxml.jackson.core:jackson-annotations")
+
+    // Spring Boot
+    implementation("org.springframework.boot:spring-boot-starter-web:$springBootVersion")
+
+    // Test dependencies
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")
+    testImplementation("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
+    testImplementation("org.junit.jupiter:junit-jupiter-params:$junitVersion")
+    testImplementation("org.assertj:assertj-core:3.24.2")
+    testImplementation("org.springframework.boot:spring-boot-starter-test:$springBootVersion")
+    testImplementation("io.mockk:mockk:1.13.7")
+}
+
+tasks {
+    val generateSpringMultipartCode = createCodeGenerationTask(
+        "generateSpringMultipartCode",
+        "src/test/resources/examples/multipartFormData/api.yaml",
+        "com.example.multipart"
+    )
+
+    withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+        compilerOptions.jvmTarget.set(JvmTarget.JVM_17)
+        dependsOn(generateSpringMultipartCode)
+    }
+
+    withType<Test> {
+        useJUnitPlatform()
+        jvmArgs = listOf("--add-opens=java.base/java.lang=ALL-UNNAMED", "--add-opens=java.base/java.util=ALL-UNNAMED")
+    }
+}
+
+fun TaskContainer.createCodeGenerationTask(
+    name: String, apiFilePath: String, basePackage: String
+): TaskProvider<JavaExec> = register(name, JavaExec::class) {
+    val apiFile = "${rootProject.projectDir}/$apiFilePath"
+    inputs.files(apiFile)
+    outputs.dir(generationDir)
+    outputs.cacheIf { true }
+    classpath = rootProject.files("./build/libs/fabrikt-${rootProject.version}.jar")
+    mainClass.set("com.cjbooms.fabrikt.cli.CodeGen")
+    args = listOf(
+        "--output-directory", generationDir,
+        "--base-package", basePackage,
+        "--api-file", apiFile,
+        "--targets", "http_models",
+        "--targets", "controllers",
+        "--http-controller-target", "SPRING",
+    )
+    dependsOn(":jar")
+    dependsOn(":shadowJar")
+}

--- a/end2end-tests/spring/src/test/kotlin/com/cjbooms/fabrikt/servers/spring/MultipartControllerImpl.kt
+++ b/end2end-tests/spring/src/test/kotlin/com/cjbooms/fabrikt/servers/spring/MultipartControllerImpl.kt
@@ -1,0 +1,44 @@
+package com.cjbooms.fabrikt.servers.spring
+
+import com.example.multipart.controllers.FilesUploadController
+import com.example.multipart.controllers.FilesUploadMultipleController
+import com.example.multipart.models.UploadResponse
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.multipart.MultipartFile
+
+@RestController
+class FilesUploadControllerImpl(
+    private val fileCapture: FileCapture
+) : FilesUploadController {
+    override fun uploadFile(file: MultipartFile, description: String?): ResponseEntity<UploadResponse> {
+        fileCapture.capturedFile = file
+        fileCapture.capturedDescription = description
+        return ResponseEntity.ok(UploadResponse(id = "file-123"))
+    }
+}
+
+@RestController
+class FilesUploadMultipleControllerImpl(
+    private val fileCapture: FileCapture
+) : FilesUploadMultipleController {
+    override fun uploadMultipleFiles(files: List<MultipartFile>, category: String): ResponseEntity<UploadResponse> {
+        fileCapture.capturedFiles = files
+        fileCapture.capturedCategory = category
+        return ResponseEntity.ok(UploadResponse(id = "file-multi"))
+    }
+}
+
+class FileCapture {
+    var capturedFile: MultipartFile? = null
+    var capturedFiles: List<MultipartFile>? = null
+    var capturedDescription: String? = null
+    var capturedCategory: String? = null
+
+    fun reset() {
+        capturedFile = null
+        capturedFiles = null
+        capturedDescription = null
+        capturedCategory = null
+    }
+}

--- a/end2end-tests/spring/src/test/kotlin/com/cjbooms/fabrikt/servers/spring/SpringMultipartServerTest.kt
+++ b/end2end-tests/spring/src/test/kotlin/com/cjbooms/fabrikt/servers/spring/SpringMultipartServerTest.kt
@@ -1,0 +1,142 @@
+package com.cjbooms.fabrikt.servers.spring
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.MediaType
+import org.springframework.mock.web.MockMultipartFile
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@WebMvcTest
+@ContextConfiguration(classes = [TestConfig::class])
+class SpringMultipartServerTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var fileCapture: FileCapture
+
+    @BeforeEach
+    fun setUp() {
+        fileCapture.reset()
+    }
+
+    @Test
+    fun `single file upload is parsed correctly with file metadata`() {
+        val fileContent = "Hello, World!".toByteArray()
+        val mockFile = MockMultipartFile(
+            "file",
+            "test.txt",
+            MediaType.TEXT_PLAIN_VALUE,
+            fileContent
+        )
+
+        val descriptionPart = MockMultipartFile(
+            "description",
+            "",
+            MediaType.TEXT_PLAIN_VALUE,
+            "Test description".toByteArray()
+        )
+
+        mockMvc.perform(
+            multipart("/files/upload")
+                .file(mockFile)
+                .file(descriptionPart)
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.id").value("file-123"))
+
+        assertThat(fileCapture.capturedFile).isNotNull
+        assertThat(fileCapture.capturedFile!!.bytes).isEqualTo(fileContent)
+        assertThat(fileCapture.capturedFile!!.originalFilename).isEqualTo("test.txt")
+        assertThat(fileCapture.capturedFile!!.contentType).isEqualTo(MediaType.TEXT_PLAIN_VALUE)
+        assertThat(fileCapture.capturedDescription).isEqualTo("Test description")
+    }
+
+    @Test
+    fun `single file upload works without optional description`() {
+        val fileContent = "Content without description".toByteArray()
+        val mockFile = MockMultipartFile(
+            "file",
+            "nodesc.txt",
+            MediaType.TEXT_PLAIN_VALUE,
+            fileContent
+        )
+
+        mockMvc.perform(
+            multipart("/files/upload")
+                .file(mockFile)
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.id").value("file-123"))
+
+        assertThat(fileCapture.capturedFile).isNotNull
+        assertThat(fileCapture.capturedFile!!.bytes).isEqualTo(fileContent)
+        assertThat(fileCapture.capturedDescription).isNull()
+    }
+
+    @Test
+    fun `multiple files upload is parsed correctly with file metadata`() {
+        val file1Content = "File 1 content".toByteArray()
+        val file2Content = "File 2 content".toByteArray()
+
+        val mockFile1 = MockMultipartFile(
+            "files",
+            "file1.txt",
+            MediaType.TEXT_PLAIN_VALUE,
+            file1Content
+        )
+        val mockFile2 = MockMultipartFile(
+            "files",
+            "file2.pdf",
+            MediaType.APPLICATION_PDF_VALUE,
+            file2Content
+        )
+
+        val categoryPart = MockMultipartFile(
+            "category",
+            "",
+            MediaType.TEXT_PLAIN_VALUE,
+            "documents".toByteArray()
+        )
+
+        mockMvc.perform(
+            multipart("/files/upload-multiple")
+                .file(mockFile1)
+                .file(mockFile2)
+                .file(categoryPart)
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.id").value("file-multi"))
+
+        assertThat(fileCapture.capturedFiles).hasSize(2)
+        assertThat(fileCapture.capturedFiles!![0].bytes).isEqualTo(file1Content)
+        assertThat(fileCapture.capturedFiles!![0].originalFilename).isEqualTo("file1.txt")
+        assertThat(fileCapture.capturedFiles!![0].contentType).isEqualTo(MediaType.TEXT_PLAIN_VALUE)
+        assertThat(fileCapture.capturedFiles!![1].bytes).isEqualTo(file2Content)
+        assertThat(fileCapture.capturedFiles!![1].originalFilename).isEqualTo("file2.pdf")
+        assertThat(fileCapture.capturedFiles!![1].contentType).isEqualTo(MediaType.APPLICATION_PDF_VALUE)
+        assertThat(fileCapture.capturedCategory).isEqualTo("documents")
+    }
+}
+
+@Configuration
+open class TestConfig {
+    @Bean
+    open fun fileCapture() = FileCapture()
+
+    @Bean
+    open fun filesUploadController(fileCapture: FileCapture) = FilesUploadControllerImpl(fileCapture)
+
+    @Bean
+    open fun filesUploadMultipleController(fileCapture: FileCapture) = FilesUploadMultipleControllerImpl(fileCapture)
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,6 +7,7 @@ include(
     "end2end-tests:ktor-client-kotlinx",
     "end2end-tests:ktor-client-jackson",
     "end2end-tests:spring-http-interface",
+    "end2end-tests:spring",
     "end2end-tests:models-jackson",
     "end2end-tests:models-kotlinx",
     "playground",

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/client/SpringHttpInterfaceGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/client/SpringHttpInterfaceGenerator.kt
@@ -22,6 +22,7 @@ import com.cjbooms.fabrikt.model.GeneratedFile
 import com.cjbooms.fabrikt.model.HeaderParam
 import com.cjbooms.fabrikt.model.IncomingParameter
 import com.cjbooms.fabrikt.model.KotlinTypeInfo
+import com.cjbooms.fabrikt.model.MultipartParameter
 import com.cjbooms.fabrikt.model.PathParam
 import com.cjbooms.fabrikt.model.QueryParam
 import com.cjbooms.fabrikt.model.RequestParameter
@@ -100,6 +101,11 @@ class SpringHttpInterfaceGenerator(
                 },
                 annotateBodyParameterWith = { _ ->
                     SpringHttpInterfaceAnnotations.requestBodyBuilder()
+                        .build()
+                },
+                annotateMultipartParameterWith = { parameter ->
+                    SpringHttpInterfaceAnnotations.requestPartBuilder()
+                        .addMember("value = %S", parameter.oasName)
                         .build()
                 }
             )

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/client/metadata/SpringHttpInterface.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/client/metadata/SpringHttpInterface.kt
@@ -13,6 +13,7 @@ object SpringHttpInterfaceImports {
     val REQUEST_HEADER = ClassName(Packages.BIND_ANNOTATION, "RequestHeader")
     val REQUEST_BODY = ClassName(Packages.BIND_ANNOTATION, "RequestBody")
     val PATH_VARIABLE = ClassName(Packages.BIND_ANNOTATION, "PathVariable")
+    val REQUEST_PART = ClassName(Packages.BIND_ANNOTATION, "RequestPart")
 
     val HTTP_EXCHANGE = ClassName(Packages.SERVICE_ANNOTATION, "HttpExchange")
 }
@@ -32,4 +33,7 @@ object SpringHttpInterfaceAnnotations {
 
     fun httpExchangeBuilder(): AnnotationSpec.Builder = AnnotationSpec
         .builder(SpringHttpInterfaceImports.HTTP_EXCHANGE)
+
+    fun requestPartBuilder(): AnnotationSpec.Builder = AnnotationSpec
+        .builder(SpringHttpInterfaceImports.REQUEST_PART)
 }

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/SpringControllerInterfaceGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/SpringControllerInterfaceGenerator.kt
@@ -33,6 +33,7 @@ import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.TypeSpec
+import com.squareup.kotlinpoet.asClassName
 
 class SpringControllerInterfaceGenerator(
     private val packages: Packages,
@@ -103,6 +104,10 @@ class SpringControllerInterfaceGenerator(
                             .addAnnotation(SpringAnnotations.requestBodyBuilder().build())
                             .maybeAddAnnotation(validationAnnotations.parameterValid())
                             .build()
+
+                    is MultipartParameter ->
+                        it
+                            .toMultipartParameterSpec()
 
                     is RequestParameter ->
                         it
@@ -187,6 +192,29 @@ class SpringControllerInterfaceGenerator(
 
             this.addAnnotation(it.build())
         }
+
+    private fun MultipartParameter.toMultipartParameterSpec(): ParameterSpec {
+        val fileType = if (schema.type == "array") {
+            List::class.asClassName().parameterizedBy(SpringImports.MULTIPART_FILE)
+        } else {
+            SpringImports.MULTIPART_FILE
+        }
+
+        val paramType = if (isFile) {
+            if (isRequired) fileType else fileType.copy(nullable = true)
+        } else {
+            type
+        }
+
+        return ParameterSpec.builder(name, paramType)
+            .addAnnotation(
+                SpringAnnotations.requestPartBuilder()
+                    .addMember("value = %S", oasName)
+                    .addMember("required = %L", isRequired)
+                    .build()
+            )
+            .build()
+    }
 
     private fun FunSpec.Builder.addSuspendModifier(): FunSpec.Builder {
         if (options.any { it == ControllerCodeGenOptionType.SUSPEND_MODIFIER }) {

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/metadata/Spring.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/metadata/Spring.kt
@@ -43,6 +43,10 @@ object SpringImports {
 
     val AUTHENTICATION = ClassName(Packages.SPRING_AUTHENTICATION, "Authentication")
 
+    val REQUEST_PART = ClassName(Packages.WEB_BIND_ANNOTATION, "RequestPart")
+
+    val MULTIPART_FILE = ClassName("org.springframework.web.multipart", "MultipartFile")
+
     val COMPLETION_STAGE = ClassName(Packages.JAVA_UTIL_CONCURRENT, "CompletionStage")
 
     object DateTimeFormat {
@@ -94,4 +98,8 @@ object SpringAnnotations {
     fun requestPathVariableBuilder(): AnnotationSpec.Builder =
         AnnotationSpec
             .builder(SpringImports.PATH_VARIABLE)
+
+    fun requestPartBuilder(): AnnotationSpec.Builder =
+        AnnotationSpec
+            .builder(SpringImports.REQUEST_PART)
 }

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/SpringControllerGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/SpringControllerGeneratorTest.kt
@@ -47,7 +47,8 @@ class SpringControllerGeneratorTest {
         "jakartaValidationAnnotations",
         "modelSuffix",
         "unsupportedInlinedDefinitions",
-        "httpStatusCodeRangeDefinition"
+        "httpStatusCodeRangeDefinition",
+        "multipartFormData",
     )
 
     private fun setupGithubApiTestEnv(annotations: ValidationAnnotations = JavaxValidationAnnotations) {

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/SpringHttpInterfaceGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/SpringHttpInterfaceGeneratorTest.kt
@@ -34,6 +34,7 @@ class SpringHttpInterfaceGeneratorTest {
         "multiMediaType",
         "pathLevelParameters",
         "parameterNameClash",
+        "multipartFormData",
     )
 
     @BeforeEach

--- a/src/test/resources/examples/multipartFormData/client/SpringHttpInterfaceClient.kt
+++ b/src/test/resources/examples/multipartFormData/client/SpringHttpInterfaceClient.kt
@@ -1,0 +1,55 @@
+package examples.multipartFormData.client
+
+import examples.multipartFormData.models.UploadResponse
+import org.springframework.web.bind.`annotation`.RequestHeader
+import org.springframework.web.bind.`annotation`.RequestParam
+import org.springframework.web.bind.`annotation`.RequestPart
+import org.springframework.web.service.`annotation`.HttpExchange
+import kotlin.Any
+import kotlin.ByteArray
+import kotlin.String
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.collections.Map
+
+@Suppress("unused")
+public interface FilesUploadClient {
+    /**
+     * Upload a single file
+     *
+     * @param file The file to upload
+     * @param description Optional description of the file
+     */
+    @HttpExchange(
+        url = "/files/upload",
+        method = "POST",
+        accept = ["application/json"],
+    )
+    public fun uploadFile(
+        @RequestPart(value = "file") `file`: ByteArray,
+        @RequestPart(value = "description") description: String? = null,
+        @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
+        @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
+    ): UploadResponse
+}
+
+@Suppress("unused")
+public interface FilesUploadMultipleClient {
+    /**
+     * Upload multiple files
+     *
+     * @param files The files to upload
+     * @param category Category for the uploaded files
+     */
+    @HttpExchange(
+        url = "/files/upload-multiple",
+        method = "POST",
+        accept = ["application/json"],
+    )
+    public fun uploadMultipleFiles(
+        @RequestPart(value = "files") files: List<ByteArray>,
+        @RequestPart(value = "category") category: String,
+        @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
+        @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
+    ): UploadResponse
+}

--- a/src/test/resources/examples/multipartFormData/controllers/spring/Controllers.kt
+++ b/src/test/resources/examples/multipartFormData/controllers/spring/Controllers.kt
@@ -1,0 +1,59 @@
+package examples.multipartFormData.controllers
+
+import examples.multipartFormData.models.UploadResponse
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Controller
+import org.springframework.validation.`annotation`.Validated
+import org.springframework.web.bind.`annotation`.RequestMapping
+import org.springframework.web.bind.`annotation`.RequestMethod
+import org.springframework.web.bind.`annotation`.RequestPart
+import org.springframework.web.multipart.MultipartFile
+import kotlin.String
+import kotlin.collections.List
+
+@Controller
+@Validated
+@RequestMapping("")
+public interface FilesUploadController {
+    /**
+     * Upload a single file
+     *
+     * @param file The file to upload
+     * @param description Optional description of the file
+     */
+    @RequestMapping(
+        value = ["/files/upload"],
+        produces = ["application/json"],
+        method = [RequestMethod.POST],
+        consumes = ["multipart/form-data"],
+    )
+    public fun uploadFile(
+        @RequestPart(value = "file", required = true) `file`: MultipartFile,
+        @RequestPart(value = "description", required = false) description: String?,
+    ): ResponseEntity<UploadResponse>
+}
+
+@Controller
+@Validated
+@RequestMapping("")
+public interface FilesUploadMultipleController {
+    /**
+     * Upload multiple files
+     *
+     * @param files The files to upload
+     * @param category Category for the uploaded files
+     */
+    @RequestMapping(
+        value = ["/files/upload-multiple"],
+        produces = ["application/json"],
+        method = [RequestMethod.POST],
+        consumes = ["multipart/form-data"],
+    )
+    public fun uploadMultipleFiles(
+        @RequestPart(value = "files", required = true)
+        files: List<MultipartFile>,
+        @RequestPart(value = "category", required = true)
+        category: String,
+    ): ResponseEntity<UploadResponse>
+}


### PR DESCRIPTION
## Summary
- Implements multipart file upload for Spring HTTP Interface client
- Implements multipart file upload for Spring MVC controller using `@RequestPart` annotation and `MultipartFile` type handling

Depends on #16