### PR TITLE
Add multipart/form-data support for OpenFeign client

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OpenFeignInterfaceGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OpenFeignInterfaceGenerator.kt
@@ -22,6 +22,7 @@ import com.cjbooms.fabrikt.model.GeneratedFile
 import com.cjbooms.fabrikt.model.HeaderParam
 import com.cjbooms.fabrikt.model.IncomingParameter
 import com.cjbooms.fabrikt.model.KotlinTypeInfo
+import com.cjbooms.fabrikt.model.MultipartParameter
 import com.cjbooms.fabrikt.model.PathParam
 import com.cjbooms.fabrikt.model.QueryParam
 import com.cjbooms.fabrikt.model.RequestParameter
@@ -96,6 +97,11 @@ class OpenFeignInterfaceGenerator(
                 annotateRequestParameterWith = { parameter ->
                     OpenFeignAnnotations.paramBuilder()
                         .addMember("%S", parameter.name)
+                        .build()
+                },
+                annotateMultipartParameterWith = { parameter ->
+                    OpenFeignAnnotations.requestPartBuilder()
+                        .addMember("value = %S", parameter.oasName)
                         .build()
                 },
             )

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/client/metadata/OpenFeign.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/client/metadata/OpenFeign.kt
@@ -21,6 +21,8 @@ object OpenFeignImports {
     val PARAM = ClassName(Packages.FEIGN, "Param")
 
     val FEIGN_CLIENT = ClassName(Packages.SPRING_STARTER, "FeignClient")
+
+    val REQUEST_PART = ClassName("org.springframework.web.bind.annotation", "RequestPart")
 }
 
 object OpenFeignAnnotations {
@@ -49,4 +51,8 @@ object OpenFeignAnnotations {
     fun feignClientBuilder(): AnnotationSpec.Builder =
         AnnotationSpec
             .builder(OpenFeignImports.FEIGN_CLIENT)
+
+    fun requestPartBuilder(): AnnotationSpec.Builder =
+        AnnotationSpec
+            .builder(OpenFeignImports.REQUEST_PART)
 }

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/OpenFeignClientGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/OpenFeignClientGeneratorTest.kt
@@ -31,6 +31,7 @@ class OpenFeignClientGeneratorTest {
         "multiMediaType",
         "pathLevelParameters",
         "parameterNameClash",
+        "multipartFormData",
     )
 
     @BeforeEach

--- a/src/test/resources/examples/multipartFormData/client/OpenFeignClient.kt
+++ b/src/test/resources/examples/multipartFormData/client/OpenFeignClient.kt
@@ -1,0 +1,49 @@
+package examples.multipartFormData.client
+
+import examples.multipartFormData.models.UploadResponse
+import feign.HeaderMap
+import feign.Headers
+import feign.QueryMap
+import feign.RequestLine
+import org.springframework.web.bind.`annotation`.RequestPart
+import kotlin.ByteArray
+import kotlin.String
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.collections.Map
+
+@Suppress("unused")
+public interface FilesUploadClient {
+    /**
+     * Upload a single file
+     *
+     * @param file The file to upload
+     * @param description Optional description of the file
+     */
+    @RequestLine("POST /files/upload")
+    @Headers("Accept: application/json")
+    public fun uploadFile(
+        @RequestPart(value = "file") `file`: ByteArray,
+        @RequestPart(value = "description") description: String? = null,
+        @HeaderMap additionalHeaders: Map<String, String> = emptyMap(),
+        @QueryMap additionalQueryParameters: Map<String, String> = emptyMap(),
+    ): UploadResponse
+}
+
+@Suppress("unused")
+public interface FilesUploadMultipleClient {
+    /**
+     * Upload multiple files
+     *
+     * @param files The files to upload
+     * @param category Category for the uploaded files
+     */
+    @RequestLine("POST /files/upload-multiple")
+    @Headers("Accept: application/json")
+    public fun uploadMultipleFiles(
+        @RequestPart(value = "files") files: List<ByteArray>,
+        @RequestPart(value = "category") category: String,
+        @HeaderMap additionalHeaders: Map<String, String> = emptyMap(),
+        @QueryMap additionalQueryParameters: Map<String, String> = emptyMap(),
+    ): UploadResponse
+}


### PR DESCRIPTION
## Summary
- Implements multipart file upload handling for OpenFeign client interface with proper annotation metadata support

Depends on #16